### PR TITLE
delete_action removal caused exception in my project

### DIFF
--- a/hitcount/admin.py
+++ b/hitcount/admin.py
@@ -32,7 +32,8 @@ class HitAdmin(admin.ModelAdmin):
         # Override the default `get_actions` to ensure that our model's
         # `delete()` method is called.
         actions = super(HitAdmin, self).get_actions(request)
-        del actions['delete_selected']
+        if 'delete_selected' in actions:
+            del actions['delete_selected']
         return actions
 
 # TODO: Add inlines to the HitCount object so we can see a list of the recent


### PR DESCRIPTION
fixed minor bug when delete_selected is not in the actions list. this happens in my projects, I am not sure why. However the behavior is not changed, it just checks first.
