### PR TITLE
Makes django_hitcount TZ aware and prevents RuntimeWarning

### DIFF
--- a/hitcount/models.py
+++ b/hitcount/models.py
@@ -11,6 +11,7 @@ from django.dispatch import Signal
 
 from django.utils.timezone import now
 
+
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 # SIGNALS #

--- a/hitcount/models.py
+++ b/hitcount/models.py
@@ -9,6 +9,8 @@ from django.contrib.contenttypes import generic
 
 from django.dispatch import Signal
 
+from django.utils.timezone import now
+
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 # SIGNALS #
@@ -62,7 +64,7 @@ class HitManager(models.Manager):
         hours, and weeks.  It's creating a datetime.timedelta object.
         '''
         grace = getattr(settings, 'HITCOUNT_KEEP_HIT_ACTIVE', {'days':7})
-        period = datetime.datetime.utcnow() - datetime.timedelta(**grace)
+        period = now() - datetime.timedelta(**grace)
         queryset = self.get_query_set()
         queryset = queryset.filter(created__gte=period)
         return queryset.filter(*args, **kwargs)
@@ -76,7 +78,7 @@ class HitCount(models.Model):
 
     '''
     hits            = models.PositiveIntegerField(default=0)
-    modified        = models.DateTimeField(default=datetime.datetime.utcnow)
+    modified        = models.DateTimeField(default=now)
     content_type    = models.ForeignKey(ContentType,
                         verbose_name="content type",
                         related_name="content_type_set_for_%(class)s",)
@@ -95,7 +97,7 @@ class HitCount(models.Model):
         return u'%s' % self.content_object
 
     def save(self, *args, **kwargs):
-        self.modified = datetime.datetime.utcnow()
+        self.modified = now()
 
         if not self.pk and self.object_pk and self.content_type:
             # Because we are using a models.TextField() for `object_pk` to
@@ -131,7 +133,7 @@ class HitCount(models.Model):
         hours, and weeks.  It's creating a datetime.timedelta object.
         '''
         assert kwargs, "Must provide at least one timedelta arg (eg, days=1)"
-        period = datetime.datetime.utcnow() - datetime.timedelta(**kwargs)
+        period = now() - datetime.timedelta(**kwargs)
         return self.hit_set.filter(created__gte=period).count()
 
     def get_content_object_url(self):
@@ -180,7 +182,7 @@ class Hit(models.Model):
         if not self.created:
             self.hitcount.hits = F('hits') + 1
             self.hitcount.save()
-            self.created = datetime.datetime.utcnow()
+            self.created = now()
 
         super(Hit, self).save(*args, **kwargs)
 


### PR DESCRIPTION
This appears to be the django documentation recommended way of handling timezone.  The warning `RuntimeWarning: DateTimeField received a naive datetime` error comes up on Mezzanine with default settings which are `TZ= True` and `Timezone = none`.  Not sure about a standard Django only install.  I believe this fix makes the app universally compatible with any TZ setting.