### PR TITLE
Fix import error python_2_unicode_compatible

### DIFF
--- a/hitcount/models.py
+++ b/hitcount/models.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.db.models import F
 from django.utils import timezone
 from django.dispatch import receiver
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
In the latest django versions python_2_unicode_compatible is in other location.