### PR TITLE
Make it possible to customize HitCount model per project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.4
   - 3.5
   - 3.6
@@ -10,8 +9,6 @@ env:
     - DJANGO=2.0
 matrix:
   exclude:
-    - python: 2.7
-      env: DJANGO=2.0
     - python: 3.5
       env: DJANGO=1.8
 install:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Django-Hitcount allows you to track the number of hits/views for a particular ob
 
    overview
    installation
+   models
    settings
    management
    example_project

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -156,34 +156,6 @@ If you have set ``count_hit=True`` (see: `HitCountDetailView`_) two additional v
     {{ hitcount.hit_message }}
 
 
-Models
-^^^^^^
-
-.. note:: You are not *required* to do anything specific with your models; django-hitcount relies on a ``GenericForeignKey`` to create the relationship to your model's ``HitCount``.
-
-If you would like to add a reverse lookup in your own model to its related ``HitCount`` you can utilize the ``hitcount.models.HitCountMixin``.
-
-::
-
-    from django.db import models
-
-    from hitcount.models import HitCountMixin
-
-    # here is an example model with a GenericRelation
-    class MyModel(models.Model, HitCountMixin):
-
-      # adding a generic relationship makes sorting by Hits possible:
-      # MyModel.objects.order_by("hit_count_generic__hits")
-      hit_count_generic = GenericRelation(
-        HitCount, object_id_field='object_pk',
-        related_query_name='hit_count_generic_relation')
-
-    # you would access your hit_count like so:
-    my_model = MyModel.objects.get(pk=1)
-    my_model.hit_count.hits                 # total number of hits
-    my_model.hit_count.hits_in_last(days=7) # number of hits in last seven days
-
-
 .. _jQuery plugin: https://github.com/thornomad/django-hitcount/blob/master/hitcount/static/hitcount/jquery.postcsrf.js
 
 .. _example project: https://github.com/thornomad/django-hitcount/tree/master/example_project

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,0 +1,45 @@
+Models
+======
+
+.. note:: You are not *required* to do anything specific with your models; django-hitcount relies on a ``GenericForeignKey`` to create the relationship to your model's ``HitCount``.
+
+If you would like to add a reverse lookup in your own model to its related ``HitCount`` you can utilize the ``hitcount.models.HitCountMixin``.
+
+::
+
+    from django.db import models
+
+    from hitcount.models import HitCountMixin
+    from hitcount.settings import MODEL_HITCOUNT
+
+    # here is an example model with a GenericRelation
+    class MyModel(models.Model, HitCountMixin):
+
+      # adding a generic relationship makes sorting by Hits possible:
+      # MyModel.objects.order_by("hit_count_generic__hits")
+      hit_count_generic = GenericRelation(
+        MODEL_HITCOUNT, object_id_field='object_pk',
+        related_query_name='hit_count_generic_relation')
+
+    # you would access your hit_count like so:
+    my_model = MyModel.objects.get(pk=1)
+    my_model.hit_count.hits                 # total number of hits
+    my_model.hit_count.hits_in_last(days=7) # number of hits in last seven days
+
+Customization
+-------------
+
+`django-hitcount` allows you to customize ``HitCount`` model.
+
+1. Define your own `hitcount` model inherited from `HitCountBase`.
+
+2. Now when `models.py` in your application has the definition of a custom hitcount model, you need
+   to instruct Django to use it for your project instead of a built-in one::
+
+    # Somewhere in your settings.py do the following.
+    # Here `myapp` is the name of your application, `MyHitCount` is the names of your customized model.
+
+    HITCOUNT_HITCOUNT_MODEL = 'myapp.MyHitCount'
+
+
+3. Run `manage.py syncdb` to install your customized models into DB.

--- a/example_project/blog/models.py
+++ b/example_project/blog/models.py
@@ -5,7 +5,8 @@ from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.contrib.contenttypes.fields import GenericRelation
 
-from hitcount.models import HitCount, HitCountMixin
+from hitcount.models import HitCountMixin
+from hitcount.settings import MODEL_HITCOUNT
 
 
 @python_2_unicode_compatible
@@ -13,7 +14,7 @@ class Post(models.Model, HitCountMixin):
     title = models.CharField(max_length=200)
     content = models.TextField()
     hit_count_generic = GenericRelation(
-        HitCount, object_id_field='object_pk',
+        MODEL_HITCOUNT, object_id_field='object_pk',
         related_query_name='hit_count_generic_relation')
 
     def __str__(self):

--- a/example_project/requirements.txt
+++ b/example_project/requirements.txt
@@ -1,2 +1,3 @@
 Django==2.2.13
+django-etc>=1.2.0
 pytz==2018.3

--- a/hitcount/admin.py
+++ b/hitcount/admin.py
@@ -4,7 +4,8 @@ from django.contrib import admin
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext_lazy as _
 
-from .models import Hit, HitCount, BlacklistIP, BlacklistUserAgent
+from .models import Hit, BlacklistIP, BlacklistUserAgent
+from .utils import get_hitcount_model
 
 
 class HitAdmin(admin.ModelAdmin):
@@ -87,7 +88,7 @@ class HitCountAdmin(admin.ModelAdmin):
     def has_add_permission(self, request):
         return False
 
-admin.site.register(HitCount, HitCountAdmin)
+admin.site.register(get_hitcount_model(), HitCountAdmin)
 
 
 class BlacklistIPAdmin(admin.ModelAdmin):

--- a/hitcount/settings.py
+++ b/hitcount/settings.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+
+MODEL_HITCOUNT = getattr(settings, 'HITCOUNT_HITCOUNT_MODEL', 'hitcount.HitCount')

--- a/hitcount/templatetags/hitcount_tags.py
+++ b/hitcount/templatetags/hitcount_tags.py
@@ -9,7 +9,8 @@ try:
 except ImportError:
     from django.urls import reverse
 
-from hitcount.models import HitCount
+from hitcount.utils import get_hitcount_model
+
 
 register = template.Library()
 
@@ -36,7 +37,7 @@ def get_hit_count_from_obj_variable(context, obj_variable, tag_name):
     except AttributeError:
         raise error_to_raise
 
-    hit_count, created = HitCount.objects.get_or_create(
+    hit_count, created = get_hitcount_model().objects.get_or_create(
         content_type=ctype, object_pk=obj.pk)
 
     return hit_count

--- a/hitcount/utils.py
+++ b/hitcount/utils.py
@@ -3,6 +3,9 @@ from __future__ import unicode_literals
 import re
 import warnings
 
+from hitcount import settings
+from etc.toolbox import get_model_class_from_settings
+
 
 # this is not intended to be an all-knowing IP address regex
 IP_RE = re.compile('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
@@ -38,6 +41,11 @@ def get_ip(request):
             pass
 
     return ip_address
+
+
+def get_hitcount_model():
+    """Returns the HitCount model, set for the project."""
+    return get_model_class_from_settings(settings, 'MODEL_HITCOUNT')
 
 
 class RemovedInHitCount13Warning(DeprecationWarning):

--- a/hitcount/views.py
+++ b/hitcount/views.py
@@ -8,8 +8,8 @@ from django.conf import settings
 from django.views.generic import View, DetailView
 
 from hitcount.utils import get_ip
-from hitcount.models import Hit, HitCount, BlacklistIP, BlacklistUserAgent
-from hitcount.utils import RemovedInHitCount13Warning
+from hitcount.models import Hit, BlacklistIP, BlacklistUserAgent
+from hitcount.utils import RemovedInHitCount13Warning, get_hitcount_model
 
 
 class HitCountMixin(object):
@@ -124,7 +124,7 @@ class HitCountJSONView(View, HitCountMixin):
         hitcount_pk = request.POST.get('hitcountPK')
 
         try:
-            hitcount = HitCount.objects.get(pk=hitcount_pk)
+            hitcount = get_hitcount_model().objects.get(pk=hitcount_pk)
         except:
             return HttpResponseBadRequest("HitCount object_pk not working")
 
@@ -148,7 +148,7 @@ class HitCountDetailView(DetailView, HitCountMixin):
     def get_context_data(self, **kwargs):
         context = super(HitCountDetailView, self).get_context_data(**kwargs)
         if self.object:
-            hit_count = HitCount.objects.get_for_object(self.object)
+            hit_count = get_hitcount_model().objects.get_for_object(self.object)
             hits = hit_count.hits
             context['hitcount'] = {'pk': hit_count.pk}
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(
     long_description=README,
     author='Damon Timm',
     author_email='damontimm@gmail.com',
+    install_requires=[
+        'django-etc>=1.2.0',
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Plugins',

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -12,9 +12,12 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.auth.models import User
 
 from hitcount.admin import HitAdmin, HitCountAdmin
-from hitcount.models import Hit, HitCount, BlacklistIP, BlacklistUserAgent
+from hitcount.models import Hit, BlacklistIP, BlacklistUserAgent
+from hitcount.utils import get_hitcount_model
 
 from blog.models import Post
+
+HitCount = get_hitcount_model()
 
 
 class HitCountAdminTest(TestCase):

--- a/tests/test_hitcount_cleanup.py
+++ b/tests/test_hitcount_cleanup.py
@@ -13,10 +13,13 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.utils.six import StringIO
 
-from hitcount.models import HitCount, Hit
+from hitcount.models import Hit
+from hitcount.utils import get_hitcount_model
 from blog.models import Post
 
 COMMAND_NAME = 'hitcount_cleanup'
+
+HitCount = get_hitcount_model()
 
 
 class HitCountCleanUp(TestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,9 +11,12 @@ except ImportError:
 from django.test import TestCase
 from django.utils import timezone
 
-from hitcount.models import Hit, HitCount, BlacklistIP, BlacklistUserAgent
+from hitcount.models import Hit, BlacklistIP, BlacklistUserAgent
+from hitcount.utils import get_hitcount_model
 
 from blog.models import Post
+
+HitCount = get_hitcount_model()
 
 
 class BlacklistUserAgentTests(TestCase):

--- a/tests/test_template_tags.py
+++ b/tests/test_template_tags.py
@@ -12,9 +12,12 @@ from django.test import TestCase
 from django.template import Template, Context, TemplateSyntaxError
 from django.utils import timezone
 
-from hitcount.models import Hit, HitCount
+from hitcount.models import Hit
+from hitcount.utils import get_hitcount_model
 
 from blog.models import Post
+
+HitCount = get_hitcount_model()
 
 
 class TemplateTagGetHitCountTests(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -19,12 +19,14 @@ from django.http import Http404
 from django.test import TestCase, RequestFactory
 from django.utils import timezone
 
-from hitcount.models import HitCount, BlacklistIP, BlacklistUserAgent
+from hitcount.models import BlacklistIP, BlacklistUserAgent
 from hitcount.views import HitCountMixin, HitCountJSONView, HitCountDetailView
 from hitcount.views import _update_hit_count, update_hit_count_ajax
-from hitcount.utils import RemovedInHitCount13Warning
+from hitcount.utils import RemovedInHitCount13Warning, get_hitcount_model
 
 from blog.models import Post
+
+HitCount = get_hitcount_model()
 
 
 class HitCountTestBase(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-       {py27,py34}-django{18},
-       {py27,py34,py35,py36}-django{111},
+       {py34}-django{18},
+       {py34,py35,py36}-django{111},
        {py34,py35,py36}-django{20}
        # {py34,py35,py36}-django{master}
 


### PR DESCRIPTION
to @thornomad I have reverted changes in 1.3.2 (since people can't deal with not-integer IDs), but also I made it possible to override ``HitCount`` model on project level for those who want and can use textual IDs.