### PR TITLE
fix: Allow ipv6 IPs to be admitted.

### DIFF
--- a/hitcount/utils.py
+++ b/hitcount/utils.py
@@ -1,12 +1,8 @@
-import re
 import warnings
 
+from ipaddress import ip_address as validate_ip
 from hitcount import settings
 from etc.toolbox import get_model_class_from_settings
-
-
-# this is not intended to be an all-knowing IP address regex
-IP_RE = re.compile(r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
 
 
 def get_ip(request):
@@ -28,15 +24,11 @@ def get_ip(request):
     if ip_address:
         # make sure we have one and only one IP
         try:
-            ip_address = IP_RE.match(ip_address)
-            if ip_address:
-                ip_address = ip_address.group(0)
-            else:
-                # no IP, probably from some dirty proxy or other device
-                # throw in some bogus IP
-                ip_address = '10.0.0.1'
-        except IndexError:
-            pass
+            validate_ip(ip_address)
+        except ValueError:
+            # no IP, probably from some dirty proxy or other device
+            # throw in some bogus IP
+            ip_address = '10.0.0.1'
 
     return ip_address
 


### PR DESCRIPTION
## Description

This PR allows for IPv6 addresses to be permitted. It does so by swapping out to using the ipaddress module for validation, which is in all currently supported versions of Python. It should resolve #105 .

## Testing instructions

I haven't been able to run the tests because they seem dependent on now-unsupported 2.7 compatibility shims, and I ran out of time. Accordingly, I haven't been able to add any. I've attempted to run with 3.10 and with 3.8. Advice?

It does seem to be working for me in production, though.
